### PR TITLE
Enable 255 as a color level

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,9 @@ const _ = (seed: string) => {
 	// Init randomizer
 	const random = seedrandom(seed);
 
-	const r = Math.floor(random() * 255);
-	const g = Math.floor(random() * 255);
-	const b = Math.floor(random() * 255);
+	const r = Math.floor(random() * 256);
+	const g = Math.floor(random() * 256);
+	const b = Math.floor(random() * 256);
 
 	return new Color(r, g, b);
 };


### PR DESCRIPTION
Currently, it is impossible to reach 255 as a color level as `Math.random` never returns 1. Since it is floored, it will never be 255. This fixes the code by making it possible to generate 255.